### PR TITLE
zuul-core: add initial header benchmarks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'nebula.netflixoss' version '8.0.0'
     id 'nebula.dependency-lock' version '8.0.0'
     id "com.google.osdetector" version "1.6.2"
+    id "me.champeau.gradle.jmh" version "0.5.0"
 }
 
 ext.githubProjectName = rootProject.name
@@ -19,16 +20,18 @@ configurations.all {
     exclude group: 'asm', module: 'asm-all'
 }
 
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+
 subprojects {
     apply plugin: 'nebula.netflixoss'
     apply plugin: 'java'
     apply plugin: 'nebula.javadoc-jar'
     apply plugin: 'nebula.dependency-lock'
-
-    repositories {
-        jcenter()
-        mavenLocal()
-    }
+    apply plugin: 'me.champeau.gradle.jmh'
 
     license {
         ignoreFailures = false

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,3 +1,40 @@
 {
-    
+    "jmh": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21"
+        }
+    },
+    "jmhCompileClasspath": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        }
+    },
+    "jmhRuntime": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        }
+    },
+    "jmhRuntimeClasspath": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        }
+    }
 }

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -55,3 +55,15 @@ test {
         showStandardStreams = false
     }
 }
+
+// ./gradlew --no-daemon clean :zuul-core:jmh --stacktrace
+jmh {
+    profilers = ["gc"]
+    timeOnIteration = "1s"
+    warmup = "1s"
+    fork = 1
+    warmupIterations = 10
+    iterations 5
+    // Not sure why duplicate classes are aon the path.  Something Nebula related I think.
+    duplicateClassesStrategy = 'EXCLUDE'
+}

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -389,6 +389,516 @@
             "requested": "1.7.25"
         }
     },
+    "jmh": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21"
+        }
+    },
+    "jmhCompileClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "locked": "0.7.5",
+            "requested": "0.7.5"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "locked": "1.9.18",
+            "requested": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.governator:governator-core": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "locked": "0.3.0",
+            "requested": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "locked": "0.7.2",
+            "requested": "0.7.2"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "0.103.0",
+            "requested": "0.103.0"
+        },
+        "commons-configuration:commons-configuration": {
+            "locked": "1.8",
+            "requested": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.21.0",
+            "requested": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "locked": "1.2.1",
+            "requested": "1.2.1"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "locked": "1.64",
+            "requested": "1.+"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "locked": "2.4.4",
+            "requested": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.25",
+            "requested": "1.7.25"
+        }
+    },
+    "jmhRuntime": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.truth:truth": {
+            "locked": "1.0.1",
+            "requested": "1.0.1"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "locked": "0.7.6",
+            "requested": "0.7.5"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "locked": "1.9.18",
+            "requested": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.governator:governator-core": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.governator:governator-test-junit": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "locked": "0.3.0",
+            "requested": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "locked": "0.12.21",
+            "requested": "0.7.2"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "0.103.0",
+            "requested": "0.103.0"
+        },
+        "commons-configuration:commons-configuration": {
+            "locked": "1.8",
+            "requested": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "locked": "2.0.30.Final",
+            "requested": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.21.0",
+            "requested": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "locked": "1.2.1",
+            "requested": "1.2.1"
+        },
+        "junit:junit": {
+            "locked": "4.13",
+            "requested": "4.13"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "locked": "1.64",
+            "requested": "1.+"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "locked": "2.4.4",
+            "requested": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.30",
+            "requested": "1.7.25"
+        },
+        "org.slf4j:slf4j-simple": {
+            "locked": "1.7.29",
+            "requested": "1.7.29"
+        }
+    },
+    "jmhRuntimeClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.truth:truth": {
+            "locked": "1.0.1",
+            "requested": "1.0.1"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "locked": "0.7.6",
+            "requested": "0.7.5"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "locked": "1.9.18",
+            "requested": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.governator:governator-core": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.governator:governator-test-junit": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "locked": "0.3.0",
+            "requested": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "locked": "0.12.21",
+            "requested": "0.7.2"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "0.103.0",
+            "requested": "0.103.0"
+        },
+        "commons-configuration:commons-configuration": {
+            "locked": "1.8",
+            "requested": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "locked": "2.0.30.Final",
+            "requested": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.21.0",
+            "requested": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "locked": "1.2.1",
+            "requested": "1.2.1"
+        },
+        "junit:junit": {
+            "locked": "4.13",
+            "requested": "4.13"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "locked": "1.64",
+            "requested": "1.+"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "locked": "2.4.4",
+            "requested": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.30",
+            "requested": "1.7.25"
+        },
+        "org.slf4j:slf4j-simple": {
+            "locked": "1.7.29",
+            "requested": "1.7.29"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.9.8",

--- a/zuul-core/src/jmh/java/com/netflix/zuul/message/HeadersBenchmark.java
+++ b/zuul-core/src/jmh/java/com/netflix/zuul/message/HeadersBenchmark.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.zuul.message;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+
+@State(Scope.Thread)
+public class HeadersBenchmark {
+
+    @State(Scope.Thread)
+    public static class AddHeaders {
+        @Param({"0", "1", "5", "10", "30"})
+        public int count;
+
+        @Param({"10"})
+        public int nameLength;
+
+        private String[] stringNames;
+        private HeaderName[] names;
+        private String[] values;
+
+        @Setup
+        public void setUp() {
+            stringNames = new String[count];
+            names = new HeaderName[stringNames.length];
+            values = new String[stringNames.length];
+            for (int i = 0; i < stringNames.length; i++) {
+                UUID uuid = new UUID(ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong());
+                String name = uuid.toString();
+                assert name.length() >= nameLength;
+                name = name.substring(0, nameLength);
+                names[i] = new HeaderName(name);
+                stringNames[i] = name;
+                values[i] = name;
+            }
+        }
+
+        @Benchmark
+        @BenchmarkMode(Mode.AverageTime)
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public Headers addHeaders_string() {
+            Headers headers = new Headers();
+            for (int i = 0; i < count; i++) {
+                headers.add(stringNames[i], values[i]);
+            }
+            return headers;
+        }
+
+        @Benchmark
+        @BenchmarkMode(Mode.AverageTime)
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public Headers addHeaders_headerName() {
+            Headers headers = new Headers();
+            for (int i = 0; i < count; i++) {
+                headers.add(names[i], values[i]);
+            }
+            return headers;
+        }
+    }
+
+
+    @State(Scope.Thread)
+    public static class GetSetHeaders {
+        @Param({"1", "5", "10", "30"})
+        public int count;
+
+        @Param({"10"})
+        public int nameLength;
+
+        private String[] stringNames;
+        private HeaderName[] names;
+        private String[] values;
+        Headers headers;
+
+        @Setup
+        public void setUp() {
+            headers = new Headers();
+            stringNames = new String[count];
+            names = new HeaderName[stringNames.length];
+            values = new String[stringNames.length];
+            for (int i = 0; i < stringNames.length; i++) {
+                UUID uuid = new UUID(ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong());
+                String name = uuid.toString();
+                assert name.length() >= nameLength;
+                name = name.substring(0, nameLength);
+                names[i] = new HeaderName(name);
+                stringNames[i] = name;
+                values[i] = name;
+                headers.add(names[i], values[i]);
+            }
+        }
+
+        @Benchmark
+        @BenchmarkMode(Mode.AverageTime)
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public void setHeader_first() {
+            headers.set(names[0], "blah");
+        }
+
+        @Benchmark
+        @BenchmarkMode(Mode.AverageTime)
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public void setHeader_last() {
+            headers.set(names[count - 1], "blah");
+        }
+
+        @Benchmark
+        @BenchmarkMode(Mode.AverageTime)
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public List<String> getHeader_first() {
+            return headers.get(names[0]);
+        }
+
+        @Benchmark
+        @BenchmarkMode(Mode.AverageTime)
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public List<String> getHeader_last() {
+            return headers.get(names[count - 1]);
+        }
+
+        @Benchmark
+        @BenchmarkMode(Mode.AverageTime)
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public void entries(Blackhole blackhole) {
+            for (Header header : headers.entries()) {
+                blackhole.consume(header);
+            }
+        }
+
+
+
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public Headers newHeaders() {
+        return new Headers();
+    }
+
+}

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -454,6 +454,717 @@
             "locked": "1.7.30"
         }
     },
+    "jmh": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21"
+        }
+    },
+    "jmhCompileClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.5"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.2"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.25"
+        }
+    },
+    "jmhRuntime": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.truth:truth": {
+            "locked": "1.0.1",
+            "requested": "1.0.1"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.6"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.12.21"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "junit:junit": {
+            "locked": "4.13",
+            "requested": "4.13"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.64"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.30"
+        }
+    },
+    "jmhRuntimeClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.truth:truth": {
+            "locked": "1.0.1",
+            "requested": "1.0.1"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.6"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.12.21"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "junit:junit": {
+            "locked": "4.13",
+            "requested": "4.13"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.64"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.30"
+        }
+    },
     "runtime": {
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.2.2",

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -904,6 +904,711 @@
             "locked": "1.7.30"
         }
     },
+    "jmh": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21"
+        }
+    },
+    "jmhCompileClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.5"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.2"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.25"
+        }
+    },
+    "jmhRuntime": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.6"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.12.21"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.13.1",
+            "requested": "2.13.1"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.13.1",
+            "requested": "2.13.1"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.64"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.30"
+        }
+    },
+    "jmhRuntimeClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.6"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.12.21"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.13.1",
+            "requested": "2.13.1"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.13.1",
+            "requested": "2.13.1"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.64"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.30"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [


### PR DESCRIPTION
* zuul-core: add initial header benchmarks

```
Benchmark                                                                           (count)  (nameLength)  Mode  Cnt     Score      Error   Units
HeadersBenchmark.AddHeaders.addHeaders_headerName                                         0            10  avgt    5    13.235 ±    0.141   ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate                          0            10  avgt    5  5760.757 ±   81.082  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate.norm                     0            10  avgt    5   120.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space                 0            10  avgt    5  5744.278 ± 1085.369  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space.norm            0            10  avgt    5   119.652 ±   22.069    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space             0            10  avgt    5     0.116 ±    0.165  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space.norm        0            10  avgt    5     0.002 ±    0.003    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.count                               0            10  avgt    5    71.000             counts
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.time                                0            10  avgt    5    46.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_headerName                                         1            10  avgt    5    62.569 ±    1.211   ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate                          1            10  avgt    5  3575.234 ±   59.966  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate.norm                     1            10  avgt    5   352.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space                 1            10  avgt    5  3550.663 ±  487.502  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space.norm            1            10  avgt    5   349.559 ±   44.697    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space             1            10  avgt    5     0.141 ±    0.174  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space.norm        1            10  avgt    5     0.014 ±    0.017    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.count                               1            10  avgt    5    70.000             counts
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.time                                1            10  avgt    5    46.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_headerName                                         5            10  avgt    5   217.592 ±    5.030   ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate                          5            10  avgt    5  2055.443 ±   53.741  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate.norm                     5            10  avgt    5   704.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space                 5            10  avgt    5  2070.276 ±  111.870  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space.norm            5            10  avgt    5   709.075 ±   30.981    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space             5            10  avgt    5     0.125 ±    0.179  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space.norm        5            10  avgt    5     0.043 ±    0.061    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.count                               5            10  avgt    5    71.000             counts
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.time                                5            10  avgt    5    46.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_headerName                                        10            10  avgt    5   420.344 ±   54.910   ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate                         10            10  avgt    5  1730.071 ±  212.700  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate.norm                    10            10  avgt    5  1144.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space                10            10  avgt    5  1730.442 ±  150.538  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space.norm           10            10  avgt    5  1144.766 ±  108.126    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space            10            10  avgt    5     0.166 ±    0.150  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space.norm       10            10  avgt    5     0.110 ±    0.099    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.count                              10            10  avgt    5    73.000             counts
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.time                               10            10  avgt    5    48.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_headerName                                        30            10  avgt    5  1376.939 ±  121.818   ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate                         30            10  avgt    5  1464.617 ±  126.901  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate.norm                    30            10  avgt    5  3176.001 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space                30            10  avgt    5  1458.484 ±   91.940  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space.norm           30            10  avgt    5  3164.292 ±  390.958    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space            30            10  avgt    5     0.199 ±    0.200  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space.norm       30            10  avgt    5     0.430 ±    0.411    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.count                              30            10  avgt    5    68.000             counts
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.time                               30            10  avgt    5    43.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_string                                             0            10  avgt    5    13.310 ±    1.138   ns/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate                              0            10  avgt    5  5729.099 ±  462.448  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate.norm                         0            10  avgt    5   120.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space                     0            10  avgt    5  5776.837 ±  668.533  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space.norm                0            10  avgt    5   120.984 ±    5.369    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space                 0            10  avgt    5     0.129 ±    0.143  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space.norm            0            10  avgt    5     0.003 ±    0.003    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.count                                   0            10  avgt    5    76.000             counts
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.time                                    0            10  avgt    5    48.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_string                                             1            10  avgt    5   240.186 ±   11.252   ns/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate                              1            10  avgt    5   993.891 ±   45.913  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate.norm                         1            10  avgt    5   376.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space                     1            10  avgt    5   998.743 ±  107.461  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space.norm                1            10  avgt    5   377.854 ±   40.246    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space                 1            10  avgt    5     0.154 ±    0.121  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space.norm            1            10  avgt    5     0.058 ±    0.045    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.count                                   1            10  avgt    5    72.000             counts
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.time                                    1            10  avgt    5    46.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_string                                             5            10  avgt    5  1122.361 ±   33.837   ns/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate                              5            10  avgt    5   466.165 ±   14.332  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate.norm                         5            10  avgt    5   824.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space                     5            10  avgt    5   463.119 ±   48.372  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space.norm                5            10  avgt    5   818.664 ±   90.576    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space                 5            10  avgt    5     0.145 ±    0.186  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space.norm            5            10  avgt    5     0.257 ±    0.332    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.count                                   5            10  avgt    5    69.000             counts
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.time                                    5            10  avgt    5    44.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_string                                            10            10  avgt    5  2274.778 ±   47.366   ns/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate                             10            10  avgt    5   386.325 ±    9.255  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate.norm                        10            10  avgt    5  1384.001 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space                    10            10  avgt    5   386.489 ±   47.807  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space.norm               10            10  avgt    5  1384.456 ±  144.856    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space                10            10  avgt    5     0.162 ±    0.154  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space.norm           10            10  avgt    5     0.580 ±    0.543    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.count                                  10            10  avgt    5    70.000             counts
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.time                                   10            10  avgt    5    44.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_string                                            30            10  avgt    5  6926.132 ±   91.277   ns/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate                             30            10  avgt    5   357.382 ±    4.648  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate.norm                        30            10  avgt    5  3896.003 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space                    30            10  avgt    5   356.889 ±   25.003  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space.norm               30            10  avgt    5  3890.807 ±  312.975    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space                30            10  avgt    5     0.158 ±    0.174  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space.norm           30            10  avgt    5     1.720 ±    1.924    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.count                                  30            10  avgt    5    63.000             counts
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.time                                   30            10  avgt    5    41.000                 ms
HeadersBenchmark.newHeaders                                                             N/A           N/A  avgt    5    13.160 ±    0.252   ns/op
HeadersBenchmark.newHeaders:·gc.alloc.rate                                              N/A           N/A  avgt    5  5790.750 ±  134.675  MB/sec
HeadersBenchmark.newHeaders:·gc.alloc.rate.norm                                         N/A           N/A  avgt    5   120.000 ±    0.001    B/op
HeadersBenchmark.newHeaders:·gc.churn.PS_Eden_Space                                     N/A           N/A  avgt    5  5799.987 ±  587.873  MB/sec
HeadersBenchmark.newHeaders:·gc.churn.PS_Eden_Space.norm                                N/A           N/A  avgt    5   120.204 ±   14.045    B/op
HeadersBenchmark.newHeaders:·gc.churn.PS_Survivor_Space                                 N/A           N/A  avgt    5     0.137 ±    0.072  MB/sec
HeadersBenchmark.newHeaders:·gc.churn.PS_Survivor_Space.norm                            N/A           N/A  avgt    5     0.003 ±    0.001    B/op
HeadersBenchmark.newHeaders:·gc.count                                                   N/A           N/A  avgt    5    79.000             counts
HeadersBenchmark.newHeaders:·gc.time                                                    N/A           N/A  avgt    5    48.000                 ms```